### PR TITLE
#1900 - Fix smr adapter

### DIFF
--- a/packages/functions/src/triggers/milestone-transactions-triggers/SmrMilestoneTransactionAdapter.ts
+++ b/packages/functions/src/triggers/milestone-transactions-triggers/SmrMilestoneTransactionAdapter.ts
@@ -61,7 +61,7 @@ export class SmrMilestoneTransactionAdapter {
         continue;
       }
       let unlock = unlocks[Math.min(i, unlocks.length - 1)] as UnlockTypes;
-      if (unlock.type !== SIGNATURE_UNLOCK_TYPE) {
+      while (unlock.type !== SIGNATURE_UNLOCK_TYPE) {
         unlock = unlocks[unlock.reference];
       }
       const senderPublicKey = (<ISignatureUnlock>unlock).signature.publicKey;


### PR DESCRIPTION
/milestone_rms/2352819/transactions/0x34bbf5a83a3ad5f893d7b23ed4056ebc7542d5d305f41bb210776955d44f6112
This milestone transactions last unlock is a ref unclock, pointing to unlock[3] which is also ref unlock pointing to unlock[1] which is signature unlock. Ref unlock can point to ref unlock thus we need while not if

<img width="267" alt="Screen Shot 2022-12-01 at 9 16 15 pm" src="https://user-images.githubusercontent.com/109557696/205151030-4263dc57-760c-446a-b8d9-8ce507f6742e.png">
