### PR TITLE
#2005 - Fix minted token claim

### DIFF
--- a/packages/functions/src/triggers/transaction-trigger/airdrop.claim.ts
+++ b/packages/functions/src/triggers/transaction-trigger/airdrop.claim.ts
@@ -143,6 +143,7 @@ const onMintedAirdropClaim = async (order: Transaction, token: Token) => {
         tokenClaimed: inc(airdrop.count),
         tokenOwned: inc(airdrop.count),
         totalUnclaimedAirdrop: inc(-airdrop.count),
+        mintedClaimedOn: serverTime(),
       }),
       { merge: true },
     );
@@ -171,7 +172,7 @@ const onMintedAirdropClaim = async (order: Transaction, token: Token) => {
         void: false,
       },
     };
-    await admin.firestore().doc(`${COL.TRANSACTION}/${credit.uid}`).create(credit);
+    await admin.firestore().doc(`${COL.TRANSACTION}/${credit.uid}`).create(cOn(credit));
   }
 };
 


### PR DESCRIPTION
Reason for this bug: mintedClaimedOn was not set.

If user only had airdropped minted tokens, after claiming it the user had X number of tokens owned. Since mintedClaimedOn was not set, the back-end treated those owned tokens as if those were owned before minting, thus the user was eligible for another X number of tokens to claim.