### PR TITLE
enable support for two character symbol

### DIFF
--- a/packages/functions/src/services/joi/common.ts
+++ b/packages/functions/src/services/joi/common.ts
@@ -19,7 +19,7 @@ export class CommonJoi {
     return required ? base.required() : base.allow(null, '').optional();
   }
   public static tokenSymbol(): AnySchema {
-    return Joi.string().min(3).max(5).regex(RegExp('^[A-Z]+$')).required();
+    return Joi.string().min(2).max(5).regex(RegExp('^[A-Z]+$')).required();
   }
 }
 

--- a/packages/ui/src/app/pages/token/services/new.service.ts
+++ b/packages/ui/src/app/pages/token/services/new.service.ts
@@ -35,7 +35,7 @@ export class NewService {
   public symbolControl: FormControl = new FormControl('', [
     Validators.required,
     Validators.pattern(/^[A-Z]+$/),
-    Validators.minLength(3),
+    Validators.minLength(2),
     Validators.maxLength(5),
   ]);
   public priceControl: FormControl = new FormControl('1', [


### PR DESCRIPTION
enable support for two character symbol. This is required for XP.