### PR TITLE
Fix collection badge access

### DIFF
--- a/.github/workflows/functions_emulated-tests.yml
+++ b/.github/workflows/functions_emulated-tests.yml
@@ -407,10 +407,10 @@ jobs:
                 npm run test:ci -- --findRelatedTests ./test/dbRoll/0.17/rank.avg.spec.ts &&
                 npm run test:ci -- --findRelatedTests ./test/dbRoll/0.17/uppercase.member.fix.spec.ts &&
                 npm run test:ci -- --findRelatedTests ./test/dbRoll/0.17/votes.roll.spec.ts &&
+                npm run test:ci -- --findRelatedTests ./test/dbRoll/0.18/badge.trans.roll.spec.ts &&
                 npm run test:ci -- --findRelatedTests ./test/dbRoll/0.18/base.token.create.spec.ts &&
                 npm run test:ci -- --findRelatedTests ./test/dbRoll/0.18/collection.discounts.roll.spec.ts &&
-                npm run test:ci -- --findRelatedTests ./test/dbRoll/0.18/collection.stat.roll.spec.ts &&
-                npm run test:ci -- --findRelatedTests ./test/dbRoll/0.18/member.award.stat.roll.spec.ts 
+                npm run test:ci -- --findRelatedTests ./test/dbRoll/0.18/collection.stat.roll.spec.ts 
              " --project dev --export-on-exit=./firestore-data
       - name: Archive firestore data
         uses: actions/upload-artifact@v3
@@ -461,13 +461,13 @@ jobs:
       - name: Test
         working-directory: packages/functions
         run: npm run milestone-sync & firebase emulators:exec "
+                npm run test:ci -- --findRelatedTests ./test/dbRoll/0.18/member.award.stat.roll.spec.ts &&
                 npm run test:ci -- --findRelatedTests ./test/dbRoll/0.18/nft.trade.stats.roll.spec.ts &&
                 npm run test:ci -- --findRelatedTests ./test/dbRoll/0.18/space.media.roll.spec.ts &&
                 npm run test:ci -- --findRelatedTests ./test/dbRoll/0.18/token.symbol.roll.spec.ts &&
                 npm run test:ci -- --findRelatedTests ./test/dbRoll/set.extra.stakes.spec.ts &&
                 npm run test:ci -- --findRelatedTests ./test/stake/delete.stake.reward.spec.ts &&
-                npm run test:ci -- --findRelatedTests ./test/stake/stake.reward.cron.spec.ts &&
-                npm run test:ci -- --findRelatedTests ./test/storage/resize.img.spec.ts 
+                npm run test:ci -- --findRelatedTests ./test/stake/stake.reward.cron.spec.ts 
              " --project dev --export-on-exit=./firestore-data
       - name: Archive firestore data
         uses: actions/upload-artifact@v3
@@ -518,6 +518,7 @@ jobs:
       - name: Test
         working-directory: packages/functions
         run: npm run milestone-sync & firebase emulators:exec "
+                npm run test:ci -- --findRelatedTests ./test/storage/resize.img.spec.ts &&
                 npm run test:ci -- --findRelatedTests ./test/storage/storage.roll.spec.ts 
              " --project dev --export-on-exit=./firestore-data
       - name: Archive firestore data

--- a/packages/functions/src/runtime/firebase/award/index.ts
+++ b/packages/functions/src/runtime/firebase/award/index.ts
@@ -21,7 +21,6 @@ const createAwardSchema = Joi.object({
     name: Joi.string().required(),
     description: Joi.string().allow(null, '').optional(),
     total: Joi.number().min(1).max(10000).integer().required(),
-    // TODO We might need to fix tests. Image must be mandatory.
     image: CommonJoi.storageUrl(),
     tokenReward: Joi.number().min(0).max(MAX_IOTA_AMOUNT).integer().required(),
     tokenSymbol: CommonJoi.tokenSymbol(),

--- a/packages/functions/src/services/validators/access.ts
+++ b/packages/functions/src/services/validators/access.ts
@@ -32,28 +32,18 @@ export const assertHasAccess = async (
   }
 
   if (access === Access.MEMBERS_WITH_BADGE) {
-    const includedBadges: string[] = [];
-    const snapshot = await admin
-      .firestore()
-      .collection(COL.TRANSACTION)
-      .where('payload.type', '==', TransactionAwardType.BADGE)
-      .where('member', '==', member)
-      .get();
-    if (snapshot.size && accessAwards.length) {
-      for (const doc of snapshot.docs) {
-        const data = doc.data();
-        if (
-          accessAwards.includes(data.payload.award) &&
-          !includedBadges.includes(data.payload.award)
-        ) {
-          includedBadges.push(data.payload.award);
-          break;
-        }
+    for (const award of accessAwards) {
+      const snapshot = await admin
+        .firestore()
+        .collection(COL.TRANSACTION)
+        .where('payload.type', '==', TransactionAwardType.BADGE)
+        .where('member', '==', member)
+        .where('payload.award', '==', award)
+        .limit(1)
+        .get();
+      if (!snapshot.size) {
+        throw throwInvalidArgument(WenError.you_dont_have_required_badge);
       }
-    }
-
-    if (accessAwards.length !== includedBadges.length) {
-      throw throwInvalidArgument(WenError.you_dont_have_required_badge);
     }
   }
 

--- a/packages/functions/test/auth.spec.ts
+++ b/packages/functions/test/auth.spec.ts
@@ -74,7 +74,7 @@ describe('Pub key test', () => {
 
     const signature = Ed25519Next.sign(
       address.keyPair.privateKey,
-      ConverterNext.utf8ToBytes(nonce),
+      Converter.utf8ToBytes(`0x${toHex(nonce)}`),
     );
     const request = {
       address: 'address',
@@ -104,7 +104,10 @@ describe('Pub key test', () => {
       const userDocRef = admin.firestore().doc(`${COL.MEMBER}/${address.bech32}`);
       await userDocRef.create({ uid: address.bech32, nonce });
 
-      const signature = Ed25519.sign(address.keyPair.privateKey, Converter.utf8ToBytes(nonce));
+      const signature = Ed25519.sign(
+        address.keyPair.privateKey,
+        Converter.utf8ToBytes(`0x${toHex(nonce)}`),
+      );
 
       const request = {
         address: 'address',
@@ -125,3 +128,9 @@ describe('Pub key test', () => {
     },
   );
 });
+
+const toHex = (stringToConvert: string) =>
+  stringToConvert
+    .split('')
+    .map((c) => c.charCodeAt(0).toString(16).padStart(2, '0'))
+    .join('');

--- a/packages/functions/test/controls/proposal.spec.ts
+++ b/packages/functions/test/controls/proposal.spec.ts
@@ -257,6 +257,7 @@ describe('ProposalController: ' + WEN_FUNC.cProposal + ' MEMBERS', () => {
       space: space?.uid,
       endDate: dayjs().add(5, 'days').toDate(),
       badge: {
+        image: MEDIA,
         name: 'Winner',
         description: 'Such a special',
         total: 1,

--- a/packages/functions/test/cron/floor-price.cron.only.spec.ts
+++ b/packages/functions/test/cron/floor-price.cron.only.spec.ts
@@ -1,4 +1,4 @@
-import { COL, Collection, MIN_IOTA_AMOUNT, NftAvailable } from '@soonaverse/interfaces';
+import { COL, Collection, MIN_IOTA_AMOUNT, NftAccess, NftAvailable } from '@soonaverse/interfaces';
 import admin from '../../src/admin.config';
 import { updateFloorPriceOnCollections } from '../../src/cron/collection.floor.price.cron';
 import { getRandomEthAddress } from '../../src/utils/wallet.utils';
@@ -19,6 +19,7 @@ describe('Collection floor price', () => {
         uid: getRandomEthAddress(),
         collection,
         available,
+        saleAccess: NftAccess.OPEN,
         availablePrice: i * MIN_IOTA_AMOUNT,
       };
       await admin.firestore().doc(`${COL.NFT}/${nft.uid}`).create(nft);

--- a/packages/functions/test/dbRoll/0.18/badge.trans.roll.spec.ts
+++ b/packages/functions/test/dbRoll/0.18/badge.trans.roll.spec.ts
@@ -1,0 +1,42 @@
+import {
+  COL,
+  MIN_IOTA_AMOUNT,
+  Transaction,
+  TransactionAwardType,
+  TransactionType,
+} from '@soonaverse/interfaces';
+import { badgeTransactionRolls } from '../../../scripts/dbUpgrades/0_18/badge.roll';
+import admin from '../../../src/admin.config';
+import { getRandomEthAddress } from '../../../src/utils/wallet.utils';
+
+describe('Roll legacy badge trans', () => {
+  it('Should roll legacy badge trans', async () => {
+    const count = 600;
+    const badges = Array.from(Array(count)).map((_, i) => ({
+      uid: getRandomEthAddress(),
+      type: 'BADGE',
+      payload: { type: '', xp: i },
+    }));
+
+    let batch = admin.firestore().batch();
+    for (let i = 0; i < badges.length; ++i) {
+      const docRef = admin.firestore().doc(`${COL.TRANSACTION}/${badges[i].uid}`);
+      batch.create(docRef, badges[i]);
+      if (i % 499 === 0) {
+        await batch.commit();
+        batch = admin.firestore().batch();
+      }
+    }
+    await batch.commit();
+
+    await badgeTransactionRolls(admin.app());
+
+    for (let i = 0; i < badges.length; ++i) {
+      const docRef = admin.firestore().doc(`${COL.TRANSACTION}/${badges[i].uid}`);
+      const badge = <Transaction>(await docRef.get()).data();
+      expect(badge.type).toBe(TransactionType.AWARD);
+      expect(badge.payload.type).toBe(TransactionAwardType.BADGE);
+      expect(badge.payload.tokenReward).toBe(i * MIN_IOTA_AMOUNT);
+    }
+  });
+});


### PR DESCRIPTION
The break statement caused includedBadges always have max 1 length.
Also we don't need all the badges, only the ones from the accessAwards and only one, so we read less data