### PR TITLE
#1087 - Fix nft id roll script

### DIFF
--- a/packages/functions/test/dbRoll/0.18/nftId.roll.spec.ts
+++ b/packages/functions/test/dbRoll/0.18/nftId.roll.spec.ts
@@ -1,5 +1,6 @@
 import { COL, Network, Nft, NftStatus } from '@soonaverse/interfaces';
-import { isEmpty } from 'lodash';
+import dayjs from 'dayjs';
+import { get } from 'lodash';
 import { fixMintedNftIds } from '../../../scripts/dbUpgrades/0.18/nftId.roll';
 import admin from '../../../src/admin.config';
 describe('Nft id roll', () => {
@@ -11,8 +12,9 @@ describe('Nft id roll', () => {
           blockId: '0xbac07a49ccf2064b5e7623231a0f71d73ab206178cfaf5d539be77a79fd72d01',
           nftId: '0x31cb6eb8022fe4f318bedd8c69f93b04df4d993a4ae4d3b52e2db899ebcf5f26',
           network: Network.RMS,
+          mintedOn: dayjs('2022-09-02').toDate(),
         },
-        status: NftStatus.MINTED,
+        status: NftStatus.WITHDRAWN,
       },
       {
         uid: '0x153277ca9a26bdee342a37e1e8cdce04d6afe327',
@@ -20,33 +22,44 @@ describe('Nft id roll', () => {
           blockId: '0xbac07a49ccf2064b5e7623231a0f71d73ab206178cfaf5d539be77a79fd72d01',
           nftId: 'wrong',
           network: Network.RMS,
+          mintedOn: dayjs('2022-09-02').toDate(),
         },
         status: NftStatus.WITHDRAWN,
       },
-      { uid: '1234' },
+      {
+        uid: '1234',
+        mintingData: {
+          blockId: '0xbac07a49ccf2064b5e7623231a0f71d73ab206178cfaf5d539be77a79fd72d01',
+          nftId: 'ok',
+          network: Network.RMS,
+          mintedOn: dayjs('2023-02-02').toDate(),
+        },
+        status: NftStatus.WITHDRAWN,
+      },
     ];
     for (const nft of nfts) {
       const docRef = admin.firestore().doc(`${COL.NFT}/${nft.uid}`);
       await docRef.set(nft);
     }
 
-    await fixMintedNftIds(admin.app(), NftStatus.MINTED);
-    await fixMintedNftIds(admin.app(), NftStatus.WITHDRAWN);
+    await fixMintedNftIds(admin.app());
 
     let docRef = admin.firestore().doc(`${COL.NFT}/${nfts[0].uid}`);
     let nft = <Nft>(await docRef.get()).data();
     expect(nft.mintingData?.nftId).toBe(
       '0x31cb6eb8022fe4f318bedd8c69f93b04df4d993a4ae4d3b52e2db899ebcf5f26',
     );
+    expect(get(nft, 'mintingData.nftIdFixed')).toBe(true);
 
     docRef = admin.firestore().doc(`${COL.NFT}/${nfts[1].uid}`);
     nft = <Nft>(await docRef.get()).data();
     expect(nft.mintingData?.nftId).toBe(
       '0xb3e773a7080c66aa5e884119cf741ad323c7725f958e3fd198b56216198efd01',
     );
+    expect(get(nft, 'mintingData.nftIdFixed')).toBe(true);
 
     docRef = admin.firestore().doc(`${COL.NFT}/${nfts[2].uid}`);
     nft = <Nft>(await docRef.get()).data();
-    expect(isEmpty(nft.mintingData)).toBe(true);
+    expect(nft.mintingData?.nftId).toBe('ok');
   });
 });

--- a/packages/indexes/src/nft.indexes.json
+++ b/packages/indexes/src/nft.indexes.json
@@ -543,6 +543,20 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "nft",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "mintingData.mintedOn",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
I have overestimated the public api, it did get rate limited.

Based on this commit https://github.com/soonaverse/soonaverse/commit/5cce62e0997423ea18378344b767f20bb3158186 I can tell, that the only problematic nftIds are the ones that were withdrawn before 2022 Oct 1. The rest was rolled.