### PR TITLE
#2250 - Fix award completed credit errors

### DIFF
--- a/.github/workflows/functions_emulated-tests.yml
+++ b/.github/workflows/functions_emulated-tests.yml
@@ -119,13 +119,13 @@ jobs:
           export GOOGLE_APPLICATION_CREDENTIALS="./test-service-account-key.json"
           npm run milestone-sync &
           firebase emulators:exec "
+                npm run test:ci -- --findRelatedTests test/dbRoll/0.19/award.completed.roll.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/dbRoll/0.19/avatar.collection.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/cron/proposal.cron.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/cron/nft-stake.cron.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/cron/floor-price.cron.only.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/workflow.spec.ts &&
-                npm run test:ci -- --findRelatedTests test/controls/workflow-online.spec.ts &&
-                npm run test:ci -- --findRelatedTests test/controls/token.order.spec.ts 
+                npm run test:ci -- --findRelatedTests test/controls/workflow-online.spec.ts 
              " --project dev --only functions,firestore,storage,ui,auth --export-on-exit=./firestore-data
       - name: Archive firestore data
         uses: actions/upload-artifact@v3
@@ -176,13 +176,13 @@ jobs:
           export GOOGLE_APPLICATION_CREDENTIALS="./test-service-account-key.json"
           npm run milestone-sync &
           firebase emulators:exec "
+                npm run test:ci -- --findRelatedTests test/controls/token.order.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token.expired.sale.cron.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token-trade.trigger.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token-trade.sell.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token-trade.buy.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token-distribution.spec.ts &&
-                npm run test:ci -- --findRelatedTests test/controls/token-distribution-auto-trigger.spec.ts &&
-                npm run test:ci -- --findRelatedTests test/controls/stake.reward.spec.ts 
+                npm run test:ci -- --findRelatedTests test/controls/token-distribution-auto-trigger.spec.ts 
              " --project dev --only functions,firestore,storage,ui,auth --export-on-exit=./firestore-data
       - name: Archive firestore data
         uses: actions/upload-artifact@v3
@@ -233,13 +233,13 @@ jobs:
           export GOOGLE_APPLICATION_CREDENTIALS="./test-service-account-key.json"
           npm run milestone-sync &
           firebase emulators:exec "
+                npm run test:ci -- --findRelatedTests test/controls/stake.reward.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/space.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/proposal.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/order.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/nft.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/nft-bidding.spec.ts &&
-                npm run test:ci -- --findRelatedTests test/controls/member.spec.ts &&
-                npm run test:ci -- --findRelatedTests test/controls/collection.spec.ts 
+                npm run test:ci -- --findRelatedTests test/controls/member.spec.ts 
              " --project dev --only functions,firestore,storage,ui,auth --export-on-exit=./firestore-data
       - name: Archive firestore data
         uses: actions/upload-artifact@v3
@@ -290,13 +290,13 @@ jobs:
           export GOOGLE_APPLICATION_CREDENTIALS="./test-service-account-key.json"
           npm run milestone-sync &
           firebase emulators:exec "
+                npm run test:ci -- --findRelatedTests test/controls/collection.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/address.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token/token.vote.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token/token.update.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token/token.set.to.sale.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token/token.rank.spec.ts &&
-                npm run test:ci -- --findRelatedTests test/controls/token/token.order.and.claim.air.spec.ts &&
-                npm run test:ci -- --findRelatedTests test/controls/token/token.create.spec.ts 
+                npm run test:ci -- --findRelatedTests test/controls/token/token.order.and.claim.air.spec.ts 
              " --project dev --only functions,firestore,storage,ui,auth --export-on-exit=./firestore-data
       - name: Archive firestore data
         uses: actions/upload-artifact@v3
@@ -347,13 +347,13 @@ jobs:
           export GOOGLE_APPLICATION_CREDENTIALS="./test-service-account-key.json"
           npm run milestone-sync &
           firebase emulators:exec "
+                npm run test:ci -- --findRelatedTests test/controls/token/token.create.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token/token.cancel.pub.sale.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token/token.airdrop.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/controls/token/token.airdrop.claim.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/api/getUpdatedAfter.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/api/getTokenPrice.spec.ts &&
-                npm run test:ci -- --findRelatedTests test/api/getMany.spec.ts &&
-                npm run test:ci -- --findRelatedTests test/api/getById.spec.ts 
+                npm run test:ci -- --findRelatedTests test/api/getMany.spec.ts 
              " --project dev --only functions,firestore,storage,ui,auth --export-on-exit=./firestore-data
       - name: Archive firestore data
         uses: actions/upload-artifact@v3
@@ -404,6 +404,7 @@ jobs:
           export GOOGLE_APPLICATION_CREDENTIALS="./test-service-account-key.json"
           npm run milestone-sync &
           firebase emulators:exec "
+                npm run test:ci -- --findRelatedTests test/api/getById.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/api/getAddresses.spec.ts &&
                 npm run test:ci -- --findRelatedTests test/api/custom.get.spec.ts 
              " --project dev --only functions,firestore,storage,ui,auth --export-on-exit=./firestore-data

--- a/packages/functions/scripts/db.upgrade.ts
+++ b/packages/functions/scripts/db.upgrade.ts
@@ -1,20 +1,21 @@
 import { COL } from '@soonaverse/interfaces';
 import crypto from 'crypto';
-import { cert, initializeApp } from 'firebase-admin/app';
+import admin from 'firebase-admin';
 import { getFirestore } from 'firebase-admin/firestore';
 import fs from 'fs';
 import glob from 'glob';
 import { FirebaseApp } from '../src/firebase/app/app';
 import serviceAccount from './serviceAccountKey.json';
 
-const app = initializeApp({
-  credential: cert(serviceAccount as any),
+const app = admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount as any),
 });
+process.env.FIREBASE_CONFIG = JSON.stringify({ projectId: serviceAccount.project_id });
 
 const execute = async () => {
   const db = getFirestore(app);
   const files = glob.sync(`./dbUpgrades/**/*.ts`);
-  for (const file of files) {
+  for (const file of files.sort()) {
     const content = fs.readFileSync(file);
     const hash = crypto.createHash('sha1').update(content).digest('hex');
 
@@ -32,7 +33,6 @@ const execute = async () => {
   }
 };
 
-const pathToImportFileName = (path: string) =>
-  path.replace('packages/functions/scripts', '.').replace('.ts', '');
+const pathToImportFileName = (path: string) => './' + path.replace('.ts', '');
 
 execute();

--- a/packages/functions/scripts/dbUpgrades/0.19/award.completed.roll.ts
+++ b/packages/functions/scripts/dbUpgrades/0.19/award.completed.roll.ts
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { SingleNodeClient, addressBalance } from '@iota/iota.js-next';
+import { COL, Transaction, TransactionCreditType, TransactionType } from '@soonaverse/interfaces';
+import { FirebaseApp } from '../../../src/firebase/app/app';
+import { Firestore } from '../../../src/firebase/firestore/firestore';
+
+const RMS_API_ENDPOINT = 'https://rms1.svrs.io/';
+const SMR_API_ENDPOINT = 'https://smr1.svrs.io/';
+
+export const awardCompletedCreditRoll = async (app: FirebaseApp) => {
+  const db = new Firestore(app);
+
+  const transactions = await db
+    .collection(COL.TRANSACTION)
+    .where('type', '==', TransactionType.CREDIT)
+    .where('payload.type', '==', TransactionCreditType.AWARD_COMPLETED)
+    .where('payload.walletReference.confirmed', '==', false)
+    .get<Transaction>();
+
+  console.log(app.getName());
+  const endpoint = app.getName() === 'soonaverse' ? SMR_API_ENDPOINT : RMS_API_ENDPOINT;
+  const client = new SingleNodeClient(endpoint);
+
+  const promises = transactions.map(async (tran) => {
+    const balance = (await addressBalance(client, tran.payload.sourceAddress)).balance;
+
+    const docRef = db.doc(`${COL.TRANSACTION}/${tran.uid}`);
+    await docRef.update({
+      'payload.amount': Number(balance),
+      'payload.walletReference.count': 1,
+      'payload.walletReference.error': null,
+      shouldRetry: true,
+    });
+  });
+  await Promise.all(promises);
+};
+
+export const roll = awardCompletedCreditRoll;

--- a/packages/functions/src/firebase/app/app.ts
+++ b/packages/functions/src/firebase/app/app.ts
@@ -1,8 +1,8 @@
-import { App } from 'firebase-admin/app';
+import admin from 'firebase-admin';
 import { IApp } from './interface';
 
 export class FirebaseApp implements IApp {
-  constructor(private readonly app: App) {}
+  constructor(private readonly app: admin.app.App) {}
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
   public getInstance = (): any => this.app;

--- a/packages/functions/test/dbRoll/0.19/award.completed.roll.spec.ts
+++ b/packages/functions/test/dbRoll/0.19/award.completed.roll.spec.ts
@@ -1,0 +1,72 @@
+import {
+  COL,
+  MIN_IOTA_AMOUNT,
+  Network,
+  Transaction,
+  TransactionCreditType,
+  TransactionType,
+} from '@soonaverse/interfaces';
+import dayjs from 'dayjs';
+import { awardCompletedCreditRoll } from '../../../scripts/dbUpgrades/0.19/award.completed.roll';
+import { soonApp } from '../../../src/firebase/app/soonApp';
+import { soonDb } from '../../../src/firebase/firestore/soondb';
+import { AddressDetails, WalletService } from '../../../src/services/wallet/wallet';
+import { dateToTimestamp } from '../../../src/utils/dateTime.utils';
+import { getRandomEthAddress } from '../../../src/utils/wallet.utils';
+import { requestFundsFromFaucet } from '../../../test-tangle/faucet';
+import { wait } from '../../controls/common';
+
+describe('Award completed trans roll', () => {
+  it('Should roll award completed roll', async () => {
+    const wallet = await WalletService.newWallet(Network.RMS);
+
+    const targetAddress = await wallet.getNewIotaAddressDetails();
+
+    const count = 2;
+    const uids = Array.from(Array(count)).map(() => getRandomEthAddress());
+    const addresses: AddressDetails[] = [];
+    for (let i = 0; i < count; ++i) {
+      const address = await wallet.getNewIotaAddressDetails();
+      addresses.push(address);
+      await requestFundsFromFaucet(Network.RMS, address.bech32, MIN_IOTA_AMOUNT + 1000 * i);
+    }
+
+    const trans = uids.map((uid, index) => ({
+      uid,
+      type: TransactionType.CREDIT,
+      network: Network.RMS,
+      payload: {
+        amount: MIN_IOTA_AMOUNT,
+        sourceAddress: addresses[index].bech32,
+        targetAddress: targetAddress.bech32,
+        type: TransactionCreditType.AWARD_COMPLETED,
+        walletReference: {
+          chainReferences: [],
+          createdOn: dateToTimestamp(dayjs()),
+          confirmed: false,
+          chainReference: null,
+          processedOn: dateToTimestamp(dayjs()),
+          error: '{"route":"blocks","httpStatus":400,"code":"400"}',
+          inProgress: false,
+          count: 6,
+        },
+      },
+      shouldRetry: false,
+      updatedOn: dateToTimestamp(dayjs()),
+    }));
+    for (const tran of trans) {
+      await soonDb().doc(`${COL.TRANSACTION}/${tran.uid}`).create(tran);
+    }
+    await awardCompletedCreditRoll(soonApp());
+
+    await wait(async () => {
+      for (const uid of uids) {
+        const tran = await soonDb().doc(`${COL.TRANSACTION}/${uid}`).get<Transaction>();
+        if (!tran?.payload?.walletReference?.confirmed) {
+          return false;
+        }
+      }
+      return true;
+    });
+  });
+});


### PR DESCRIPTION
There are only 33 AWARD_COMPLETED transactions that failed in prod, all belonging to legacy awards.
The reason is that collection storage deposit was bigger at creation than at actual minting time. For some reason media type was 'application/octet-stream' at creation instead of png/jpg. But when minting it was correctly set as png/jpg.
Created this roll script now, let's see if any other errors like this happen.