### PR TITLE
#2177 - Auth tests

### DIFF
--- a/packages/functions/test/auth.spec.ts
+++ b/packages/functions/test/auth.spec.ts
@@ -1,6 +1,7 @@
 import { Ed25519, Ed25519 as Ed25519Next } from '@iota/crypto.js-next';
 import { Converter, Converter as ConverterNext } from '@iota/util.js-next';
-import { COL, Member, Network, WenError, WEN_FUNC } from '@soonaverse/interfaces';
+import { recoverPersonalSignature } from '@metamask/eth-sig-util';
+import { COL, Member, Network, WEN_FUNC, WenError } from '@soonaverse/interfaces';
 import jwt from 'jsonwebtoken';
 import { get } from 'lodash';
 import { soonDb } from '../src/firebase/firestore/soondb';
@@ -13,6 +14,8 @@ import * as wallet from '../src/utils/wallet.utils';
 import { decodeAuth, getRandomNonce } from '../src/utils/wallet.utils';
 import { createMember, expectThrow, mockWalletReturnValue } from './controls/common';
 import { testEnv } from './set-up';
+
+jest.mock('@metamask/eth-sig-util');
 
 describe('Auth control test', () => {
   let walletSpy: jest.SpyInstance;
@@ -127,6 +130,116 @@ describe('Pub key test', () => {
       expect(user.validatedAddress![network]).toBe(address.bech32);
     },
   );
+
+  it.each([Network.RMS, Network.SMR])('Should throw wrong pub key', async (network: Network) => {
+    const wallet = (await WalletService.newWallet(network)) as SmrWallet;
+    const address = await wallet.getNewIotaAddressDetails();
+
+    const nonce = getRandomNonce();
+    const userDocRef = soonDb().doc(`${COL.MEMBER}/${address.bech32}`);
+    await userDocRef.create({ uid: address.bech32, nonce });
+
+    const signature = Ed25519Next.sign(
+      address.keyPair.privateKey,
+      Converter.utf8ToBytes(`0x${toHex(nonce)}`),
+    );
+
+    const wallet2 = (await WalletService.newWallet(
+      network === Network.SMR ? Network.RMS : Network.SMR,
+    )) as SmrWallet;
+    const secondAddress = await wallet2.getNewIotaAddressDetails();
+    const request = {
+      address: 'address',
+      signature: ConverterNext.bytesToHex(signature),
+      publicKey: {
+        hex: ConverterNext.bytesToHex(secondAddress.keyPair.publicKey),
+        network,
+      },
+      body: {},
+    };
+    try {
+      await decodeAuth(request, WEN_FUNC.aProposal);
+      fail();
+    } catch (error: any) {
+      expect(error.details.key).toBe(WenError.failed_to_decode_token.key);
+    }
+  });
+
+  it('Should update nonce when public key sign in', async () => {
+    const wallet = (await WalletService.newWallet(Network.RMS)) as SmrWallet;
+    const address = await wallet.getNewIotaAddressDetails();
+
+    const nonce = getRandomNonce();
+    const userDocRef = soonDb().doc(`${COL.MEMBER}/${address.bech32}`);
+    await userDocRef.create({ uid: address.bech32, nonce });
+
+    const signature = Ed25519Next.sign(
+      address.keyPair.privateKey,
+      Converter.utf8ToBytes(`0x${toHex(nonce)}`),
+    );
+    const request = {
+      address: 'address',
+      signature: ConverterNext.bytesToHex(signature),
+      publicKey: {
+        hex: ConverterNext.bytesToHex(address.keyPair.publicKey),
+        network: Network.RMS,
+      },
+      body: {},
+    };
+
+    const result = await decodeAuth(request, WEN_FUNC.aProposal);
+
+    expect(result.address).toBe(address.bech32);
+
+    const user = <Member>await userDocRef.get();
+    expect(user.validatedAddress![Network.RMS]).toBe(address.bech32);
+    expect(user.nonce).not.toBe(nonce);
+  });
+
+  it('Should update nonce when metamask sign in', async () => {
+    const address = wallet.getRandomEthAddress();
+
+    const nonce = getRandomNonce();
+    const userDocRef = soonDb().doc(`${COL.MEMBER}/${address}`);
+    await userDocRef.create({ uid: address, nonce });
+
+    const recoverPersonalSignatureMock = recoverPersonalSignature as jest.Mock;
+    recoverPersonalSignatureMock.mockReturnValue(address);
+
+    const request = {
+      address,
+      signature: 'signature',
+      body: {},
+    };
+
+    const result = await decodeAuth(request, WEN_FUNC.aProposal);
+    expect(result.address).toBe(address);
+
+    const user = await userDocRef.get<Member>();
+    expect(user?.nonce).not.toBe(nonce);
+
+    recoverPersonalSignatureMock.mockRestore();
+  });
+
+  it('Should throw with metamask sign in, wrong signature', async () => {
+    const address = wallet.getRandomEthAddress();
+
+    const nonce = getRandomNonce();
+    const userDocRef = soonDb().doc(`${COL.MEMBER}/${address}`);
+    await userDocRef.create({ uid: address, nonce });
+
+    const request = {
+      address,
+      signature: 'signature',
+      body: {},
+    };
+    try {
+      await decodeAuth(request, WEN_FUNC.aProposal);
+      fail();
+    } catch (error: any) {
+      expect(error.details.key).toBe(WenError.invalid_signature.key);
+    }
+  });
 });
 
 const toHex = (stringToConvert: string) =>

--- a/packages/functions/test/controls/common.ts
+++ b/packages/functions/test/controls/common.ts
@@ -1,12 +1,12 @@
 import {
   COL,
   Network,
-  Space,
   SUB_COL,
+  Space,
+  TOKEN_SALE_TEST,
   Token,
   TokenDistribution,
   TokenStatus,
-  TOKEN_SALE_TEST,
   TransactionOrder,
   TransactionOrderType,
   TransactionType,
@@ -20,7 +20,7 @@ import * as config from '../../src/utils/config.utils';
 import { serverTime } from '../../src/utils/dateTime.utils';
 import * as ipUtils from '../../src/utils/ip.utils';
 import * as wallet from '../../src/utils/wallet.utils';
-import { getWallet, MEDIA, testEnv } from '../set-up';
+import { MEDIA, getWallet, testEnv } from '../set-up';
 
 export const mockWalletReturnValue = <T>(walletSpy: any, address: string, body: T) =>
   walletSpy.mockReturnValue(Promise.resolve({ address, body }));


### PR DESCRIPTION
- [ ] try to auth with address that is not either ETH/SMR/IOTA/RMS/ATOI address. It should throw error. Both createMember function and decodeAuth
@adamunchained I think there is not much to validate here. 
- [x] try to login with invalid key for each wallet type ETH/SMR/IOTA/RMS/ATOI
- [ ] try ETH/SMR/IOTA/RMS/ATOI with wrong network
 We don't do networks on auth
 - [x] set SMR/IOTA/RMS/ATOI as validated address when they log in with it. If no address set, well technically there shouldn’t be for anyone yet.
 - [x] validate nonce was refreshed, this is important otherwise someone else could to reply hack.
 - [x] try to login with RMS address and network SMR vice versa (should throw error)