### PR TITLE
Use tags instead of keywords

### DIFF
--- a/docs/docs/products/dao-management/space/how-to/update-space.md
+++ b/docs/docs/products/dao-management/space/how-to/update-space.md
@@ -1,6 +1,6 @@
 ---
 title: Update Space
-keywords:
+tags:
   - how-to
   - update
   - space

--- a/docs/docs/products/overview.md
+++ b/docs/docs/products/overview.md
@@ -1,6 +1,6 @@
 ---
 title: 'BUILD.5 Products'
-keywords: ['products', 'api', 'blockchain', 'nft', 'digital twin', 'token', 'staking', 'trading', 'launchpad', 'staking', 'reputation', 'member', 'project', 'proposal', 'stake reward', 'token distribution', 'dao management']
+tags: ['products', 'api', 'blockchain', 'nft', 'digital twin', 'token', 'staking', 'trading', 'launchpad', 'staking', 'reputation', 'member', 'project', 'proposal', 'stake reward', 'token distribution', 'dao management']
 ---
 
 Learn about the BUILD.5 products and how to use them.


### PR DESCRIPTION
Found some remaining occurrences of keywords in some overview pages. Now a nice thing of this change is that people now can click on the tags to get all articles related to certain topics